### PR TITLE
Add DICOMDIR.dcm to IGNORED_FILES

### DIFF
--- a/src/jpl/labcas/validation/const.py
+++ b/src/jpl/labcas/validation/const.py
@@ -7,7 +7,7 @@ PHI_PII_THRESHOLD = 0.8  # Default score ≥ to this means the file is probably 
 PROCESS_TIMEOUT   = 30   # How many seconds to wait for a process to finish
 
 # Files to ignore when scanning for DICOM files
-IGNORED_FILES = {'.DS_Store', 'Thumbs.db', 'desktop.ini', 'DICOMDIR', 'Image.dir', 'Series.dir', '_OLD_'}
+IGNORED_FILES = {'.DS_Store', 'Thumbs.db', 'desktop.ini', 'DICOMDIR', 'DICOMDIR.dcm', 'Image.dir', 'Series.dir', '_OLD_'}
 
 # Folders whose contents we can skip completely
 IGNORED_FOLDERS = {'thumbnails'}


### PR DESCRIPTION
## 📜 Summary

This pull request adds `DICOMDIR.dcm` to the list of files to ignore when traversing the filesystem. The software was already ignoring `DICOMDIR`; now it will ignore `DICOMDIR.dcm` too.

@hoodriverheather as "pull requests" may be a bit unfamiliar, just do the following:

1. Review the explanation under "🩺 Test Data and/or Report" below
2. Review the code changes under the "± Files changed tab" above
3. If everything looks good, click the green "Review changes ▼" button, check "Approve", then click "Submit review".

If some things aren't quite right, type a comment into the box, check "Request changes", and then click "Submit review".


## 🩺 Test Data and/or Report

I set up a "test" collection `testdata/issue/12/Lung_Team_Project_2/Images_Site_weRc6TUHvOru6A/b` with two files in it:

- `DICOMDIR`
- `DICOMDIR.dcm`

Note: the software was already ignoring `DICOMDIR`.

I then ran the software before modification. It produced a 33 line `.csv` report and the following log:

```
INFO 🔍 Not using Solr (no URL provided)
INFO 🔍 Creating non-Solr paths iterator for testdata/issue/12/Lung_Team_Project_2
INFO 🔍 Scanning directory: testdata/issue/12/Lung_Team_Project_2
INFO 📁 Using SQLite database for findings: /var/folders/pk/sjzjgt614jd2w9f80bm17f6w0000gn/T/labcas_validation_findings_vavd5ifo.db
INFO 📊 Processed 2906 findings, stored in database
INFO 🔍 Found 2906 findings
INFO 🔍 Wrote database in: /var/folders/pk/sjzjgt614jd2w9f80bm17f6w0000gn/T/labcas_validation_findings_vavd5ifo.db
INFO 📝 Generating CSV reports
INFO Opening database at /var/folders/pk/sjzjgt614jd2w9f80bm17f6w0000gn/T/labcas_validation_findings_vavd5ifo.db for reading
INFO Found 1 unique site IDs
INFO Processing site ID «unknown site»
INFO Processing event ID «unknown event» and opening file reports/Lung_Team_Project_2/«unknown site»-«unknown event».csv
INFO Closing database connection
INFO Finished generating CSV reports
INFO Database findings preserved in /var/folders/pk/sjzjgt614jd2w9f80bm17f6w0000gn/T/labcas_validation_findings_vavd5ifo.db
```

I then added `DICOMDIR.dcm` to the list of files to ignore and reran the software. **This time, it didn't even produce a `.csv` file**. And here's the log:

```
INFO 🔍 Not using Solr (no URL provided)
INFO 🔍 Creating non-Solr paths iterator for testdata/issue/12/Lung_Team_Project_2
INFO 🔍 Scanning directory: testdata/issue/12/Lung_Team_Project_2
INFO 📁 Using SQLite database for findings: /var/folders/pk/sjzjgt614jd2w9f80bm17f6w0000gn/T/labcas_validation_findings_5hgigfc0.db
INFO 📊 Processed 0 findings, stored in database
INFO 🔍 Found 0 findings
INFO 🔍 Wrote database in: /var/folders/pk/sjzjgt614jd2w9f80bm17f6w0000gn/T/labcas_validation_findings_5hgigfc0.db
INFO 📝 Generating CSV reports
INFO Opening database at /var/folders/pk/sjzjgt614jd2w9f80bm17f6w0000gn/T/labcas_validation_findings_5hgigfc0.db for reading
INFO Found 0 unique site IDs
INFO Closing database connection
INFO Finished generating CSV reports
INFO Database findings preserved in /var/folders/pk/sjzjgt614jd2w9f80bm17f6w0000gn/T/labcas_validation_findings_5hgigfc0.db
```


## 🧩 Related Issues

- #12 
