### PR TITLE
Additional anonymized values to exclude

### DIFF
--- a/src/jpl/labcas/validation/_functions.py
+++ b/src/jpl/labcas/validation/_functions.py
@@ -67,6 +67,44 @@ def check_directory(target: str):
     raise DirectoryError(f'🫙 No valid DICOM files found in {target}')
 
 
+def is_anonymized_value(s: str) -> bool:
+    '''Check if a value should be considered anonymized and skipped.
+    
+    Returns True if the value:
+    - Starts with "anon" (case-insensitive), OR
+    - Matches "Doe John", "Doe^John", "John Doe", or "John^Doe" (case-insensitive)
+    '''
+    if not s:
+        return False
+    s_stripped = s.strip()
+    if not s_stripped:
+        return False
+    
+    s_lower = s_stripped.lower()
+    
+    # Check if starts with "anon"
+    if s_lower.startswith('anon'):
+        return True
+    
+    # Check for "Doe John" patterns (case-insensitive)
+    # Match: "Doe John", "Doe^John", "John Doe", "John^Doe"
+    # Also handle trailing carets/spaces and multiple carets
+    normalized = s_stripped.rstrip('^').strip()
+    normalized_lower = normalized.lower()
+    
+    # Check exact matches for common patterns
+    if normalized_lower in ('doe john', 'john doe', 'doe^john', 'john^doe'):
+        return True
+    
+    # Check if it matches the pattern with optional spaces/carets
+    # Pattern: (Doe|John) followed by (space or ^) followed by (John|Doe)
+    doe_john_pattern = re.compile(r'^(doe|john)[\s\^]+(john|doe)', re.IGNORECASE)
+    if doe_john_pattern.match(normalized):
+        return True
+    
+    return False
+
+
 def textify_dicom_value(value: any) -> list[str]:
     '''Textify the given value.
     

--- a/src/jpl/labcas/validation/_functions.py
+++ b/src/jpl/labcas/validation/_functions.py
@@ -72,7 +72,8 @@ def is_anonymized_value(s: str) -> bool:
     
     Returns True if the value:
     - Starts with "anon" (case-insensitive), OR
-    - Matches "Doe John", "Doe^John", "John Doe", or "John^Doe" (case-insensitive)
+    - Matches "Doe John", "Doe^John", "John Doe", or "John^Doe" (case-insensitive), OR
+    - Matches the specific anonymized value "P0HeLkT8KYKj14Q7GTGJjL^ry_x+LTzqsQgC9B5hZWso"
     '''
     if not s:
         return False
@@ -86,11 +87,16 @@ def is_anonymized_value(s: str) -> bool:
     if s_lower.startswith('anon'):
         return True
     
+    # Check for specific anonymized value
+    # Also handle trailing carets/spaces
+    normalized = s_stripped.rstrip('^').strip()
+    normalized_lower = normalized.lower()
+    if normalized_lower == 'p0helkt8kykj14q7gtgjjl^ry_x+ltzqsqgc9b5hzwso':
+        return True
+    
     # Check for "Doe John" patterns (case-insensitive)
     # Match: "Doe John", "Doe^John", "John Doe", "John^Doe"
     # Also handle trailing carets/spaces and multiple carets
-    normalized = s_stripped.rstrip('^').strip()
-    normalized_lower = normalized.lower()
     
     # Check exact matches for common patterns
     if normalized_lower in ('doe john', 'john doe', 'doe^john', 'john^doe'):

--- a/src/jpl/labcas/validation/phi_pii_recognizers/_simple_scoring.py
+++ b/src/jpl/labcas/validation/phi_pii_recognizers/_simple_scoring.py
@@ -540,12 +540,14 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
             # Gather all the text candidates from the value
             candidates: list[str] = self._textify(value)
 
+            # Initialize tag_keyword for this iteration
+            tag_keyword = datadict.keyword_for_tag(t) or ''
+
             # Skip institution names if we're suppressing them
             if self._suppress_institution_names and (t.group, t.element) == (0x0008, 0x0080): continue
 
             # Auto-flag truly risky tags and only when we have real text
             if (t.group, t.element) in self._strict_tags:
-                # tag_keyword already retrieved above
                 for c in candidates:
                     c = c.strip()
                     # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)

--- a/src/jpl/labcas/validation/phi_pii_recognizers/_simple_scoring.py
+++ b/src/jpl/labcas/validation/phi_pii_recognizers/_simple_scoring.py
@@ -230,6 +230,9 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
             for key, rx in self._patterns.items():
                 for m in rx.finditer(text):
                     excerpt = text[max(0, m.start() - 24):m.end() + 24]  # Grab 24 characters of context on each side
+                    # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+                    if self._is_anonymized_value(excerpt):
+                        continue
                     finding = ImageFinding(
                         file=potential_file, value=self._displayable_str(excerpt), pattern=key,
                         score=IMAGE_SCORE, index=idx
@@ -275,6 +278,43 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
         '''Normalizes a string by removing null bytes, stripping, and truncating.'''
         s = (s or '').replace('\x00', '').strip()
         return s[:self._max_normalized_string] if len(s) > self._max_normalized_string else s
+
+    def _is_anonymized_value(self, s: str) -> bool:
+        '''Check if a value should be considered anonymized and skipped.
+        
+        Returns True if the value:
+        - Starts with "anon" (case-insensitive), OR
+        - Matches "Doe John", "Doe^John", "John Doe", or "John^Doe" (case-insensitive)
+        '''
+        if not s:
+            return False
+        s_stripped = s.strip()
+        if not s_stripped:
+            return False
+        
+        s_lower = s_stripped.lower()
+        
+        # Check if starts with "anon"
+        if s_lower.startswith('anon'):
+            return True
+        
+        # Check for "Doe John" patterns (case-insensitive)
+        # Match: "Doe John", "Doe^John", "John Doe", "John^Doe"
+        # Also handle trailing carets/spaces and multiple carets
+        normalized = s_stripped.rstrip('^').strip()
+        normalized_lower = normalized.lower()
+        
+        # Check exact matches for common patterns
+        if normalized_lower in ('doe john', 'john doe', 'doe^john', 'john^doe'):
+            return True
+        
+        # Check if it matches the pattern with optional spaces/carets
+        # Pattern: (Doe|John) followed by (space or ^) followed by (John|Doe)
+        doe_john_pattern = re.compile(r'^(doe|john)[\s\^]+(john|doe)', re.IGNORECASE)
+        if doe_john_pattern.match(normalized):
+            return True
+        
+        return False
 
     def _is_pn_with_none(self, s: str) -> bool:
         '''Check if a DICOM Person Name (PN) value contains "NONE" as any component.
@@ -325,10 +365,13 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
 
         _recurse(obj)
 
-        # Deduplicate while preserving order
+        # Deduplicate while preserving order and filter out anonymized values
         seen, uniq = set(), []
         for s in out:
             if s not in seen:
+                # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+                if self._is_anonymized_value(s):
+                    continue
                 seen.add(s)
                 uniq.append(s)
         return uniq
@@ -454,6 +497,9 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
                     c = c.strip()
                     if not c:
                         continue
+                    # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+                    if self._is_anonymized_value(c):
+                        continue
                     if 'anonymized' in c.lower():
                         continue
                     # Check anonymized patterns
@@ -493,9 +539,12 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
 
             # Auto-flag truly risky tags and only when we have real text
             if (t.group, t.element) in self._strict_tags:
-                tag_keyword = datadict.keyword_for_tag(t)
+                # tag_keyword already retrieved above
                 for c in candidates:
                     c = c.strip()
+                    # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+                    if self._is_anonymized_value(c):
+                        continue
                     if 'anonymized' in c.lower():
                         continue
                     # Check for anonymized values in DICOM person name format (e.g., "Anonymous^^^^")
@@ -520,13 +569,14 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
                         findings.append(finding)
 
             # Pattern-based detection (emails, phone numbers, SSNs, DOBs, person names, etc.)
+            # tag_keyword already retrieved above, but get it from element if available for consistency
             elem = ds.get_item(t)
             # RawDataElement objects don't have a keyword attribute, so use getattr with fallback to datadict
-            tag_keyword = getattr(elem, 'keyword', None) if elem is not None else None
-            if tag_keyword is None:
-                tag_keyword = datadict.keyword_for_tag(t) or ''
+            elem_keyword = getattr(elem, 'keyword', None) if elem is not None else None
+            if elem_keyword is None:
+                tag_keyword = tag_keyword or datadict.keyword_for_tag(t) or ''
             else:
-                tag_keyword = tag_keyword or ''
+                tag_keyword = elem_keyword or tag_keyword or ''
             vendor_context = tag_keyword in self._vendor_safe_tags
 
             # Allow name-like patterns where the keyword says it's a name or when value-representation
@@ -535,6 +585,10 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
 
             for c in candidates:
                 if not c.strip(): continue
+
+                # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+                if self._is_anonymized_value(c):
+                    continue
 
                 # Skip PN values with "NONE" as a component (e.g., "NAME^NONE")
                 if vr == 'PN' and self._is_pn_with_none(c):

--- a/src/jpl/labcas/validation/phi_pii_recognizers/_simple_scoring.py
+++ b/src/jpl/labcas/validation/phi_pii_recognizers/_simple_scoring.py
@@ -284,7 +284,8 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
         
         Returns True if the value:
         - Starts with "anon" (case-insensitive), OR
-        - Matches "Doe John", "Doe^John", "John Doe", or "John^Doe" (case-insensitive)
+        - Matches "Doe John", "Doe^John", "John Doe", or "John^Doe" (case-insensitive), OR
+        - Matches the specific anonymized value "P0HeLkT8KYKj14Q7GTGJjL^ry_x+LTzqsQgC9B5hZWso"
         '''
         if not s:
             return False
@@ -298,11 +299,16 @@ class SimpleScoring_PHI_PII_Recognizer(PHI_PII_Recognizer):
         if s_lower.startswith('anon'):
             return True
         
+        # Check for specific anonymized value
+        # Also handle trailing carets/spaces
+        normalized = s_stripped.rstrip('^').strip()
+        normalized_lower = normalized.lower()
+        if normalized_lower == 'p0helkt8kykj14q7gtgjjl^ry_x+ltzqsqgc9b5hzwso':
+            return True
+        
         # Check for "Doe John" patterns (case-insensitive)
         # Match: "Doe John", "Doe^John", "John Doe", "John^Doe"
         # Also handle trailing carets/spaces and multiple carets
-        normalized = s_stripped.rstrip('^').strip()
-        normalized_lower = normalized.lower()
         
         # Check exact matches for common patterns
         if normalized_lower in ('doe john', 'john doe', 'doe^john', 'john^doe'):

--- a/src/jpl/labcas/validation/validators/_base.py
+++ b/src/jpl/labcas/validation/validators/_base.py
@@ -5,7 +5,7 @@
 from .._classes import Validator
 from .._files import PotentialFile
 from .._findings import ValidationFinding, WarningFinding
-from .._functions import textify_dicom_value
+from .._functions import textify_dicom_value, is_anonymized_value
 from pydicom.dataelem import convert_raw_data_element
 import re, pydicom, logging
 from pydicom import datadict
@@ -72,6 +72,9 @@ class RegexValidator(Validator):
                 for v in value:
                     v = v.strip()
                     if not v: continue
+                    # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+                    if is_anonymized_value(v):
+                        continue
                     _logger.debug(
                         '🫆 Class %s checking value «%s» for tag %s in %s',
                         self.__class__.__name__, v, self.tag, potential_file
@@ -118,8 +121,12 @@ class CaseInsensitiveAndWarningRegexValidator(RegexValidator):
         try:
             return super().validate(potential_file)
         except self._CaseMismatchError as ex:
+            # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+            value = ex.args[0] if ex.args else ''
+            if is_anonymized_value(value):
+                return set()
             tag_name = datadict.keyword_for_tag(self.tag) if self.tag else 'unknown tag'
             return set([WarningFinding(
-                file=potential_file, value=f'«{ex.args[0]}»', tag=self.tag,
+                file=potential_file, value=f'«{value}»', tag=self.tag,
                 description=f'{self.tag} Value for {tag_name} matches expected pattern but uses incorrect case; {self.description}'
             )])

--- a/src/jpl/labcas/validation/validators/_core.py
+++ b/src/jpl/labcas/validation/validators/_core.py
@@ -10,7 +10,7 @@ https://docs.google.com/spreadsheets/d/1Q56vKzK0nB4UAkfLJnBOy6C-7wtHccvZkWYGQHTM
 from .._classes import Validator
 from .._files import PotentialFile
 from .._findings import ValidationFinding, WarningFinding
-from .._functions import textify_dicom_value
+from .._functions import textify_dicom_value, is_anonymized_value
 from ._base import RegexValidator, DICOMUIDValidator, YMDValidator, CaseInsensitiveAndWarningRegexValidator
 from pydicom.dataelem import convert_raw_data_element
 from collections.abc import Sequence
@@ -377,29 +377,35 @@ class ImageTypeValidator(Validator):
                 try:
                     values = elem.value.decode().split('\\')
                     if len(values) > 0:
-                        if values[0].strip().upper() not in ('ORIGINAL', 'DERIVED'):
-                            if values[0].strip() in ('original', 'derived'):
-                                findings.add(WarningFinding(
-                                    file=potential_file, value=values[0], tag=self.tag,
-                                    description=f'ImageType must start with "ORIGINAL" or "DERIVED" in ALL CAPS'
-                                ))
-                            else:
-                                findings.add(ValidationFinding(
-                                    file=potential_file, value=values[0], tag=self.tag,
-                                    description=f'ImageType must start with "ORIGINAL" or "DERIVED"'
-                                ))
-                        if len(values) > 1:
-                            if values[1].strip().upper() not in ('PRIMARY', 'SECONDARY'):
-                                if values[1].strip() in ('primary', 'secondary'):
+                        val0 = values[0].strip()
+                        # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+                        if not is_anonymized_value(val0):
+                            if val0.upper() not in ('ORIGINAL', 'DERIVED'):
+                                if val0 in ('original', 'derived'):
                                     findings.add(WarningFinding(
-                                        file=potential_file, value=values[1], tag=self.tag,
-                                        description=f'ImageType must have a second string that is "PRIMARY" or "SECONDARY" in ALL CAPS'
+                                        file=potential_file, value=val0, tag=self.tag,
+                                        description=f'ImageType must start with "ORIGINAL" or "DERIVED" in ALL CAPS'
                                     ))
                                 else:
                                     findings.add(ValidationFinding(
-                                        file=potential_file, value=values[1], tag=self.tag,
-                                        description=f'ImageType must have a second string that is "PRIMARY" or "SECONDARY"'
+                                        file=potential_file, value=val0, tag=self.tag,
+                                        description=f'ImageType must start with "ORIGINAL" or "DERIVED"'
                                     ))
+                        if len(values) > 1:
+                            val1 = values[1].strip()
+                            # Skip anonymized values (starts with "anon" or matches "Doe John" patterns)
+                            if not is_anonymized_value(val1):
+                                if val1.upper() not in ('PRIMARY', 'SECONDARY'):
+                                    if val1 in ('primary', 'secondary'):
+                                        findings.add(WarningFinding(
+                                            file=potential_file, value=val1, tag=self.tag,
+                                            description=f'ImageType must have a second string that is "PRIMARY" or "SECONDARY" in ALL CAPS'
+                                        ))
+                                    else:
+                                        findings.add(ValidationFinding(
+                                            file=potential_file, value=val1, tag=self.tag,
+                                            description=f'ImageType must have a second string that is "PRIMARY" or "SECONDARY"'
+                                        ))
                 except Exception:
                     findings.add(ValidationFinding(
                         file=potential_file, value='Non-text', tag=self.tag, description=f'ImageType has non-text values'


### PR DESCRIPTION
## 📜 Summary

This pull request modifies the software to ignore anonymized values, including:

- `P0HeLkT8KYKj14Q7GTGJjL^ry_x+LTzqsQgC9B5hZWso`
- `Doe John` and its variants like `Doe^John` or `JOHN DOE`
- Anything starting with `anon` regardless of case

@hoodriverheather as "pull requests" may be a bit unfamiliar, just do the following:

1. Review the explanation under "🩺 Test Data and/or Report" below
2. Review the code changes under the "± Files changed tab" above
3. If everything looks good, click the green "Review changes ▼" button, check "Approve", then click "Submit review".

If some things aren't quite right, type a comment into the box, check "Request changes", and then click "Submit review".


## 🩺 Test Data and/or Report

I set up a "test" collection `testdata/issue/10/Prostate_MRI/Images_Site_qfP7OH9pjawWGA/1234567` with four files in it:

- `a1.dcm` (aka `anon-1.dcm`) has `anonymous` in the "PatientName" field
- `a2.dcm` (aka `anon-2.dcm`) has `anonymous` in the "SeriesInstanceUID" field
- `hash.dcm` has `P0HeLkT8KYKj14Q7GTGJjL^ry_x+LTzqsQgC9B5hZWso` in the "ReferringPhysicianName" field
- `jd.dcm` (aka `john-doe.dcm`) has `John Doe` in the "PerformingPhysicianName" field

Running the unmodified software produced findings for all of the above files for the mentioned fields:

[before.csv](https://github.com/user-attachments/files/25169601/before.csv)

After modifying the software, the findings were gone for the above:

[after.csv](https://github.com/user-attachments/files/25169602/after.csv)


## 🧩 Related Issues

- #10



