### PR TITLE
Resolve #8 with single CSV files per site instead of per-site/per-event

### DIFF
--- a/src/jpl/labcas/validation/_classes.py
+++ b/src/jpl/labcas/validation/_classes.py
@@ -207,15 +207,15 @@ class Report:
                             'index_val': index_val
                         })
                     
-                    # Process each event for this site
-                    for event_id in sorted(event_file_findings.keys()):
-                        # Write CSV file for this site_id-event_id combination
-                        output_file = os.path.join(output_directory, f'{site_id}-{event_id}.csv')
-                        _logger.info('Processing event ID %s and opening file %s', event_id, output_file)
-                        with open(output_file, 'w', newline='') as io:
-                            writer = csv.writer(io)
-                            writer.writerow(_header)
-                            
+                    # Write single CSV file for this site_id (all events combined)
+                    output_file = os.path.join(output_directory, f'{site_id}.csv')
+                    _logger.info('Opening file %s for site ID %s', output_file, site_id)
+                    with open(output_file, 'w', newline='') as io:
+                        writer = csv.writer(io)
+                        writer.writerow(_header)
+                        
+                        # Process all events for this site
+                        for event_id in sorted(event_file_findings.keys()):
                             file_findings = event_file_findings[event_id]
                             for file_path, finding_types in sorted(file_findings.items()):
                                 file_name = os.path.basename(file_path)
@@ -257,14 +257,14 @@ class Report:
             _logger.info('Using in-memory findings list')
             organized = self._organize_report()
             for site_id, event_ids in organized.items():
-                # Process all events for this site
-                for event_id in sorted(event_ids.keys()):
-                    # Write CSV file for this site_id-event_id combination
-                    output_file = os.path.join(output_directory, f'{site_id}-{event_id}.csv')
-                    _logger.info('Processing event ID %s and opening file %s', event_id, output_file)
-                    with open(output_file, 'w', newline='') as io:
-                        writer = csv.writer(io)
-                        writer.writerow(_header)
+                # Write single CSV file for this site_id (all events combined)
+                output_file = os.path.join(output_directory, f'{site_id}.csv')
+                _logger.info('Opening file %s for site ID %s', output_file, site_id)
+                with open(output_file, 'w', newline='') as io:
+                    writer = csv.writer(io)
+                    writer.writerow(_header)
+                    # Process all events for this site
+                    for event_id in sorted(event_ids.keys()):
                         file_names = event_ids[event_id]
                         for file_name, findings in sorted(file_names.items()):
                             kinds = sorted(list(set([f.kind() for f in findings])))


### PR DESCRIPTION

## 📜 Summary
This pull request modifies the Validation tool to combine all events for a given site into a single CSV file.

@hoodriverheather as "pull requests" may be a bit unfamiliar, just do the following:

1. Review the explanation under "🩺 Test Data and/or Report" below
2. Review the code changes under the "± Files changed tab" above
3. If everything looks good, click the green "Review changes ▼" button, check "Approve", then click "Submit review".

If some things aren't quite right, type a comment into the box, check "Request changes", and then click "Submit review".

## 🩺 Test Data and/or Report

I set up a "pseudo LabCAS disk" with the following structure:
```
testdata/issue/8
├── Lung_Team_Project_2
│   ├── Images_Site_1
│   │   ├── 1234567
│   │   │   ├── a.dcm
│   │   │   └── b.dcm
│   │   ├── 2345678
│   │   │   ├── c.dcm
│   │   │   └── d.dcm
│   ├── Images_Site_2
│   │   ├── 3456789
│   │   │   ├── e.dcm
│   │   │   └── f.dcm
│   │   ├── 4567890
│   │   │   └── g.dcm
└── Prostate_MRI
    ├── Images_Site_a
    │   ├── 1111111
    │   │   ├── i.dcm
    │   │   └── j.dcm
    │   ├── 2222222
    │   │   ├── k.dcm
    │   │   └── m.dcm
    │   ├── 3333333
    │   │   ├── n.dcm
    │   │   ├── p.dcm
    │   │   ├── q.dcm
    │   │   └── r.dcm
    │   ├── 4444444
    │   │   ├── s.dcm
    │   │   └── t.dcm
    └── Images_Site_b
        ├── 5555555
        │   ├── u.dcm
        │   └── v.dcm
        └── 6666666
            └── x.dcm
```
All the `.dcm` files were identical and their contents unimportant to this request.

Running the unmodified software produced finding files in the following structure:
```
before
├── Lung_Team_Project_2
│   ├── Images_Site_1-1234567.csv
│   ├── Images_Site_1-2345678.csv
│   └── Images_Site_2-3456789.csv
└── Prostate_MRI
    ├── Images_Site_a-1111111.csv
    ├── Images_Site_a-2222222.csv
    ├── Images_Site_a-3333333.csv
    ├── Images_Site_a-4444444.csv
    ├── Images_Site_b-5555555.csv
    └── Images_Site_b-6666666.csv
```

You can see the detailed the actual files in this `.zip` archive:

[before.zip](https://github.com/user-attachments/files/25192521/before.zip)

Re-running the reports with the _modified_ software produced this simpler structure:
```
afrter
├── Lung_Team_Project_2
│   ├── Images_Site_1.csv
│   └── Images_Site_2.csv
└── Prostate_MRI
    ├── Images_Site_a.csv
    └── Images_Site_b.csv
```
You can see the detailed the actual files in this `.zip` archive:

[after.zip](https://github.com/user-attachments/files/25192525/after.zip)


## 🧩 Related Issues

- #8 
