### PR TITLE
Resolve #6

### DIFF
--- a/src/jpl/labcas/validation/_classes.py
+++ b/src/jpl/labcas/validation/_classes.py
@@ -3,7 +3,7 @@
 '''🛂 EDRN DICOM Validation: classes.'''
 
 from __future__ import annotations
-from ._findings import Finding
+from ._findings import Finding, WarningFinding, ErrorFinding
 from functools import lru_cache
 from dataclasses import dataclass
 from typing import ClassVar, Optional
@@ -171,11 +171,11 @@ class Report:
             _logger.info('Opening database at %s for reading', self.db_path)
             conn = sqlite3.connect(self.db_path, timeout=30.0)
             try:
-                # Get all unique site_ids
+                # Get all unique site_ids (include Warning/Error findings regardless of score)
                 cursor = conn.execute('''
                     SELECT DISTINCT site_id 
                     FROM findings 
-                    WHERE score >= ?
+                    WHERE finding_type IN ('WarningFinding', 'ErrorFinding') OR score >= ?
                     ORDER BY site_id
                 ''', (self.score,))
                 
@@ -184,11 +184,11 @@ class Report:
 
                 for site_id in site_ids:
                     _logger.info('Processing site ID %s', site_id)
-                    # Get all findings for this site (all events), grouped by file
+                    # Get all findings for this site (all events), grouped by file (include Warning/Error regardless of score)
                     cursor = conn.execute('''
                         SELECT event_id, file_path, file_name, finding_type, value, score, tag, description, pattern, index_val
                         FROM findings
-                        WHERE site_id = ? AND score >= ?
+                        WHERE site_id = ? AND (finding_type IN ('WarningFinding', 'ErrorFinding') OR score >= ?)
                         ORDER BY event_id, file_path, finding_type, score DESC
                     ''', (site_id, self.score))
                     
@@ -269,8 +269,12 @@ class Report:
                         for file_name, findings in sorted(file_names.items()):
                             kinds = sorted(list(set([f.kind() for f in findings])))
                             for kind in kinds:
+                                # Include warnings and errors regardless of score; others must meet threshold
+                                meets_threshold = lambda f: f.kind() == kind and (
+                                    isinstance(f, (WarningFinding, ErrorFinding)) or f.score >= self.score
+                                )
                                 scored_findings = sorted(
-                                    [f for f in findings if f.score >= self.score and f.kind() == kind],
+                                    [f for f in findings if meets_threshold(f)],
                                     key=lambda x: x.score, reverse=True
                                 )
                                 if len(scored_findings) > 0:

--- a/src/jpl/labcas/validation/_files.py
+++ b/src/jpl/labcas/validation/_files.py
@@ -144,11 +144,15 @@ class PotentialFile:
         if sop_class_uid.startswith('1.2.840.10008.5.1.4.1.1.2'):
             if self._special_image_types.intersection(image_type):
                 return ProfileName.CT_LOC
+            elif len(image_type) == 0:
+                return ProfileName.MISSING_IMAGE_TYPE
             else:
                 return ProfileName.CT_STD
         elif sop_class_uid.startswith('1.2.840.10008.5.1.4.1.1.4'):
             if self._special_image_types.intersection(image_type):
                 return ProfileName.MR_LOC
+            elif len(image_type) == 0:
+                return ProfileName.MISSING_IMAGE_TYPE
             else:
                 return ProfileName.MR_STD
         elif sop_class_uid.startswith('1.2.840.10008.5.1.4.1.1.128'):

--- a/src/jpl/labcas/validation/_profiles.py
+++ b/src/jpl/labcas/validation/_profiles.py
@@ -22,6 +22,7 @@ class ProfileName(Enum):
     SC      = 'Secondary capture'
     SEG     = 'Segmentation objects'
     GENERIC = 'Generic'
+    MISSING_IMAGE_TYPE = 'Missing ImageType'
 
 
 class Profile:

--- a/src/jpl/labcas/validation/main.py
+++ b/src/jpl/labcas/validation/main.py
@@ -27,7 +27,7 @@ to get the summary.
 from ._argparse import add_standard_argparse_options
 from ._classes import Report
 from ._files import PotentialFile
-from ._findings import Finding, ErrorFinding, WarningFinding
+from ._findings import Finding, ErrorFinding
 from ._profiles import get_profile, ProfileName
 from ._functions import check_directory, iterate_paths
 from .const import PHI_PII_THRESHOLD
@@ -112,13 +112,16 @@ def _scan_one(potential_file: PotentialFile) -> int | list[Finding]:
     try:
         # Short circuit: if the profile is Generic or NULL, skip full validation and report as warning
         # (profile_name is a property that always resolves to a ProfileName, so None only before first access)
-        if potential_file.profile_name is None or potential_file.profile_name in (ProfileName.GENERIC, ProfileName.NULL):
+        if potential_file.profile_name is None or potential_file.profile_name in (ProfileName.GENERIC, ProfileName.NULL, ProfileName.MISSING_IMAGE_TYPE):
             _logger.warning('🤷 Skipping file %s because it does not have a recognized profile', potential_file)
-            findings = [WarningFinding(
+            message = 'Skipping file because it does not have a recognized profile — FAIL!'
+            if potential_file.profile_name == ProfileName.MISSING_IMAGE_TYPE:
+                message += ' — note: it has a recognized SOPClassUID but no ImageType value, which is still FAIL!'
+            findings = [ErrorFinding(
                 file=potential_file,
-                value='No valid profile found for file',
-                score=0.0,
-                description='Skipping file because it does not have a recognized profile'
+                value='FAIL! No valid profile found for file',
+                score=1.0,
+                error_message=message
             )]
         else:
             findings: set[Finding] = set()

--- a/src/jpl/labcas/validation/main.py
+++ b/src/jpl/labcas/validation/main.py
@@ -27,8 +27,8 @@ to get the summary.
 from ._argparse import add_standard_argparse_options
 from ._classes import Report
 from ._files import PotentialFile
-from ._findings import Finding
-from ._profiles import get_profile
+from ._findings import Finding, ErrorFinding, WarningFinding
+from ._profiles import get_profile, ProfileName
 from ._functions import check_directory, iterate_paths
 from .const import PHI_PII_THRESHOLD
 from .phi_pii_recognizers import PHI_PII_RECOGNIZERS, DEFAULT_PHI_PII_RECOGNIZER
@@ -110,14 +110,24 @@ def _scan_one(potential_file: PotentialFile) -> int | list[Finding]:
         - If db_path is None: list of Finding objects (for single-process mode)
     '''
     try:
-        # We need the pixel data because we also do OCR to see if there's PHI/PII burnt into the image
-        findings: set[Finding] = set()
-        findings.update(_recognizer.recognize(potential_file))
+        # Short circuit: if the profile is Generic or NULL, skip full validation and report as warning
+        # (profile_name is a property that always resolves to a ProfileName, so None only before first access)
+        if potential_file.profile_name is None or potential_file.profile_name in (ProfileName.GENERIC, ProfileName.NULL):
+            _logger.warning('🤷 Skipping file %s because it does not have a recognized profile', potential_file)
+            findings = [WarningFinding(
+                file=potential_file,
+                value='No valid profile found for file',
+                score=0.0,
+                description='Skipping file because it does not have a recognized profile'
+            )]
+        else:
+            findings: set[Finding] = set()
+            findings.update(_recognizer.recognize(potential_file))
 
-        # And now to validate the tags against a chosen profile of validators
-        profile = get_profile(potential_file.profile_name)
-        findings.update(profile.validate(potential_file))        
-        findings = list(findings)
+            # And now to validate the tags against a chosen profile of validators
+            profile = get_profile(potential_file.profile_name)
+            findings.update(profile.validate(potential_file))        
+            findings = list(findings)
 
         if _db_path is None:
             # Single-process mode: return findings directly
@@ -177,7 +187,7 @@ def _create_findings_db(db_path: str):
 
 def _load_findings_from_db(db_path: str) -> list[Finding]:
     '''Load all findings from the database and reconstruct Finding objects.'''
-    from ._findings import ErrorFinding, ValidationFinding, HeaderFinding, ImageFinding
+    from ._findings import ErrorFinding, ValidationFinding, HeaderFinding, ImageFinding, WarningFinding
     from ._files import PotentialFile
     from pydicom.tag import Tag
     
@@ -216,6 +226,8 @@ def _load_findings_from_db(db_path: str) -> list[Finding]:
                 finding = HeaderFinding(file=potential_file, value=value, score=score, tag=tag_obj, description=description)
             elif finding_type == 'ImageFinding':
                 finding = ImageFinding(file=potential_file, value=value, score=score, pattern=pattern or 'unknown', index=index_val or -1)
+            elif finding_type == 'WarningFinding':
+                finding = WarningFinding(file=potential_file, value=value, score=score, tag=tag_obj, description=description)
             else:
                 # Unknown finding type - log warning and skip
                 _logger.warning('⚠️ Unknown finding type "%s" for file %s, skipping', finding_type, file_path)


### PR DESCRIPTION
## 📜 Summary

This pull request modifies the software so that if the profile of a DICOM file cannot be determined (due to bad SOPClassUID, or unrecognized ImageType) that the file is just logged has having no valid profile. No further scans are performed.

@hoodriverheather as "pull requests" may be a bit unfamiliar, just do the following:

1. Review the explanation under "🩺 Test Data and/or Report" below
2. Review the code changes under the "± Files changed tab" above
3. If everything looks good, click the green "Review changes ▼" button, check "Approve", then click "Submit review".

If some things aren't quite right, type a comment into the box, check "Request changes", and then click "Submit review".

## 🩺 Test Data and/or Report

I set up a test collection, dataset, and event folder layout in `testdata/issue/6/Lung_Team_Project_2/Images_Site_NVRiRYzqspbvMw/1111111/` and added one file, `0001_ser006img001_CTThoraxHigh_25mmchest.dcm` to it. This file is known to @hoodriverheather to have a bad SOPClassUID.

Before changing the software, the validator produced this report:

```csv
Site ID,Event ID,File Name,Profile,Score,Findings,Details
Images_Site_NVRiRYzqspbvMw,1111111,0001_ser006img001_CTThoraxHigh_25mmchest.dcm,Generic,1.0,⚠️ Missing Required Tags,"(0020,000D) (StudyInstanceUID), «0001», Failed core tag validation: Value for tag does not match expected pattern: StudyInstanceUID must be a valid DICOM UID of digits and dots; at least one dot, no leading/trailing dots; up to 64 characters — please review for completeness and format"
```

A copy of the report is here:

[before.csv](https://github.com/user-attachments/files/25217975/before.csv)

After modifying the software, the report now looks like this:

```csv
Site ID,Event ID,File Name,Profile,Score,Findings,Details
Images_Site_NVRiRYzqspbvMw,1111111,0001_ser006img001_CTThoraxHigh_25mmchest.dcm,Generic,0.0,👮 Warning,"No valid profile found for file, Skipping file because it does not have a recognized profile"
```

A copy of the report is here:

[after.csv](https://github.com/user-attachments/files/25217976/after.csv)


## 🧩 Related Issues

- #6 
