### PR TITLE
Resolve #13 by attempting to decode PixelSpacing as floating point (and possibly scientific) numbers

### DIFF
--- a/src/jpl/labcas/validation/validators/_core.py
+++ b/src/jpl/labcas/validation/validators/_core.py
@@ -296,12 +296,54 @@ class WindowWidthValidator(RegexValidator):
         return findings
 
 
-class PixelSpacingValidator(RegexValidator):
+class PixelSpacingValidator(Validator):
     '''A validator that checks the PixelSpacing tag.'''
 
-    description = 'PixelSpacing must be a pair of positive numers' 
+    description = 'PixelSpacing must be a pair of positive floating point numbers'
     tag = pydicom.tag.Tag((0x0028, 0x0030))
-    regex = re.compile(r'^\[(\d+\.\d+|[1-9]\d*),\s+(\d+\.\d+|[1-9]\d*)\]$')
+
+    def validate(self, potential_file: PotentialFile) -> set[ValidationFinding]:
+        '''Validate that PixelSpacing has exactly two positive floats (e.g. decimal or scientific notation).'''
+        findings: set[ValidationFinding] = set()
+        ds = potential_file.dcmread(stop_before_pixels=True, force=False)
+        elem = ds.get_item(self.tag)
+        if elem is None:
+            findings.add(ValidationFinding(
+                file=potential_file, value='tag missing', tag=self.tag,
+                description='PixelSpacing tag is missing'
+            ))
+            return findings
+        elem = convert_raw_data_element(elem)
+        value = elem.value
+        if value is None:
+            findings.add(ValidationFinding(
+                file=potential_file, value='value missing', tag=self.tag,
+                description='PixelSpacing tag has no value'
+            ))
+            return findings
+        values_iter = [value] if (isinstance(value, str) or not isinstance(value, Sequence)) else list(value)
+        if len(values_iter) != 2:
+            findings.add(ValidationFinding(
+                file=potential_file, value=value, tag=self.tag,
+                description=f'PixelSpacing must be exactly two values (got {len(values_iter)})'
+            ))
+            return findings
+        for i, v in enumerate(values_iter):
+            try:
+                n = float(v)
+            except (ValueError, TypeError):
+                findings.add(ValidationFinding(
+                    file=potential_file, value=value, tag=self.tag,
+                    description=f'PixelSpacing value {i + 1} must be a floating point number (decimal or scientific notation)'
+                ))
+                return findings
+            if n <= 0:
+                findings.add(ValidationFinding(
+                    file=potential_file, value=value, tag=self.tag,
+                    description=f'PixelSpacing values must be positive (value {i + 1} is {n})'
+                ))
+                return findings
+        return findings
 
 
 class ImagePositionPatientValidator(RegexValidator):


### PR DESCRIPTION
## 📜 Summary

This pull request modifies the Validation tool's treatment of PixelSpacing as follows:

- It no longer parses it as a string
- It retrieves values of PixelSpacing and ensures there two
- It attempt to convert each value into a floating point number (possibly scientific)
- It asserts that each number is > 0

@hoodriverheather as "pull requests" may be a bit unfamiliar, just do the following:

1. Review the explanation under "🩺 Test Data and/or Report" below
2. Review the code changes under the "± Files changed tab" above
3. If everything looks good, click the green "Review changes ▼" button, check "Approve", then click "Submit review".

If some things aren't quite right, type a comment into the box, check "Request changes", and then click "Submit review".

🩺 Test Data and/or Report

I set up a collection in `testdata/issue/13/Lung_Team_Project_2/LTP2-Site6/5135903` with a file `pixel-spacing.dcm`, which is just a copy of `1.3.46.670589.33.1.1008195348577622084.2638162378990705187.dcm` from the LabCAS disk, but with a name that's a lot easier to type.

Before modifying the software, I ran it on this collection of one file and got this report:

[before.csv](https://github.com/user-attachments/files/25218476/before.csv)

Note line 2 of the report:

> ⚠️ Missing Required Tags,"(0028,0030) (PixelSpacing), «[6.840039E-001, 6.840039E-001]», Failed core tag validation: Value for tag does not match expected pattern: PixelSpacing must be a pair of positive numers — please review for completeness and format

I modified the software and reran it do get this report:

[after.csv](https://github.com/user-attachments/files/25218480/after.csv)

Note that in this report, there is no mention of PixelSpacing, and the line count of the `.csv` file went down by 1.


## 🧩 Related Issues

- #13 
