### PR TITLE
Three Updates for #11

### DIFF
--- a/src/jpl/labcas/validation/_files.py
+++ b/src/jpl/labcas/validation/_files.py
@@ -135,6 +135,7 @@ class PotentialFile:
             return None
 
     _special_image_types = set[str](['localizer', 'scout', 'survey', 'surview', 'top', 'topogram', 'scanogram'])
+    _derived_image_types = set[str](['derived', 'reformatted', 'mpr', 'mip', 'minip', 'average', 'subtracted', 'projection'])
 
     def _determine_profile_name(self, ds: pydicom.Dataset):
         from ._profiles import ProfileName
@@ -144,6 +145,8 @@ class PotentialFile:
         if sop_class_uid.startswith('1.2.840.10008.5.1.4.1.1.2'):
             if self._special_image_types.intersection(image_type):
                 return ProfileName.CT_LOC
+            elif self._derived_image_types.intersection(image_type):
+                return ProfileName.CT_DER
             elif len(image_type) == 0:
                 return ProfileName.MISSING_IMAGE_TYPE
             else:
@@ -151,6 +154,8 @@ class PotentialFile:
         elif sop_class_uid.startswith('1.2.840.10008.5.1.4.1.1.4'):
             if self._special_image_types.intersection(image_type):
                 return ProfileName.MR_LOC
+            elif self._derived_image_types.intersection(image_type):
+                return ProfileName.MR_DER
             elif len(image_type) == 0:
                 return ProfileName.MISSING_IMAGE_TYPE
             else:

--- a/src/jpl/labcas/validation/_profiles.py
+++ b/src/jpl/labcas/validation/_profiles.py
@@ -1,6 +1,15 @@
 # encoding: utf-8
 
-'''🛂 EDRN DICOM Validation: profiles.'''
+'''🛂 EDRN DICOM Validation: profiles.
+
+These valdation profiles are defined in "the spreadsheet", specifically the "SOP Class UID Routing" tab
+to determine which sets of validators go where, and then the "CORE DICOM TAGS (MR & CT)" tab that
+actually defines the validators themselves.
+
+See:
+
+https://docs.google.com/spreadsheets/d/1PMhUL_4aLE89G98KM_cDGJKaIcuMEEYWeIQSxY5d6yY/edit?gid=1779958583#gid=1779958583
+'''
 
 from enum import Enum
 from ._classes import Validator
@@ -19,6 +28,8 @@ class ProfileName(Enum):
     MR_LOC  = 'MR localizer'
     MR_STD  = 'MR standard'
     PET_STD = 'PET standard'
+    CT_DER  = 'CT derived or post-processed'
+    MR_DER  = 'MR derived or post-processed'
     SC      = 'Secondary capture'
     SEG     = 'Segmentation objects'
     GENERIC = 'Generic'
@@ -289,3 +300,46 @@ register_profile(Profile(ProfileName.GENERIC, [
     validators.ImagePositionPatientValidator(),
     validators.ImageOrientationPatientValidator(),
 ]))
+
+
+# Derrrr-profiles; from "the spreadsheet", these are identical to each other,
+# so we'll collect the validators once and then register them for both der profiles.
+
+_required_der_validators = [
+    validators.SOPClassUIDValidator(),
+    validators.ModalityValidator(),
+    validators.ImageTypeValidator(),
+    validators.SeriesDescriptionValidator(),
+    validators.FrameOfReferenceUIDValidator(),
+    validators.StudyInstanceUIDValidator(),
+    validators.SeriesInstanceUIDValidator(),
+    validators.SOPInstanceUIDValidator(),
+    validators.SeriesNumberValidator(),
+    validators.InstanceNumberValidator(),
+    validators.ManufacturerValidator(),
+    validators.ModelNameValidator(),
+    validators.SoftwareVersionsValidator(),
+    validators.StudyDateValidator(),
+    validators.ContentDateValidator(),
+    validators.AcquisitionDateValidator(),
+    validators.AcquisitionTimeValidator(),
+    validators.ContentTimeValidator(),
+    validators.RowsValidator(),
+    validators.ColumnsValidator(),
+    validators.BitsAllocatedValidator(),
+    validators.BitsStoredValidator(),
+    validators.HighBitValidator(),
+    validators.PixelRepresentationValidator(),
+    validators.PhotometricInterpretationValidator(),
+]
+_optional_der_validators = [
+    validators.WindowCenterValidator(),
+    validators.WindowWidthValidator(),
+    validators.SliceThicknessValidator(),
+    validators.PixelSpacingValidator(),
+    validators.ImagePositionPatientValidator(),
+    validators.ImageOrientationPatientValidator(),
+]
+
+register_profile(Profile(ProfileName.CT_DER, _required_der_validators, _optional_der_validators))
+register_profile(Profile(ProfileName.MR_DER, _required_der_validators, _optional_der_validators))

--- a/src/jpl/labcas/validation/_profiles.py
+++ b/src/jpl/labcas/validation/_profiles.py
@@ -74,7 +74,7 @@ PROFILES: dict[ProfileName, Profile] = {}
 from . import validators
 register_profile(Profile(ProfileName.NULL, [], []))
 
-# For CT_STD, MR_STD, and PET_STD the validators are the same and they're all required, so
+# For CT_STD and  MR_STD the validators are the same and they're all required, so
 # let's collect them here in a single list and use them for all these profiles.
 _all_required_validators = [
     validators.SOPClassUIDValidator(),
@@ -156,6 +156,43 @@ _optional_loc_validators = [
 
 register_profile(Profile(ProfileName.CT_LOC, _required_loc_validators, _optional_loc_validators,))
 register_profile(Profile(ProfileName.MR_LOC, _required_loc_validators, _optional_loc_validators,))
+
+# PET_STD is similar to CT_STD and MR_STD … but has 3 different optional validators
+register_profile(Profile(ProfileName.PET_STD, [
+    validators.SOPClassUIDValidator(),
+    validators.ModalityValidator(),
+    validators.ImageTypeValidator(),
+    validators.SeriesDescriptionValidator(),
+    validators.FrameOfReferenceUIDValidator(),
+    validators.StudyInstanceUIDValidator(),
+    validators.SeriesInstanceUIDValidator(),
+    validators.SOPInstanceUIDValidator(),
+    validators.SeriesNumberValidator(),
+    validators.InstanceNumberValidator(),
+    validators.ManufacturerValidator(),
+    validators.ModelNameValidator(),
+    validators.SoftwareVersionsValidator(),
+    validators.StudyDateValidator(),
+    validators.ContentDateValidator(),
+    validators.AcquisitionDateValidator(),
+    validators.AcquisitionTimeValidator(),
+    validators.ContentTimeValidator(),
+    validators.RowsValidator(),
+    validators.ColumnsValidator(),
+    validators.BitsAllocatedValidator(),
+    validators.BitsStoredValidator(),
+    validators.HighBitValidator(),
+    validators.PixelRepresentationValidator(),
+    validators.PhotometricInterpretationValidator(),
+    validators.PixelSpacingValidator(),
+    validators.ImagePositionPatientValidator(),
+    validators.ImageOrientationPatientValidator(),
+], [
+    validators.WindowCenterValidator(),
+    validators.WindowWidthValidator(),
+    validators.SliceThicknessValidator(),
+]))
+
 
 # "Segmentation objects", whatever these are
 register_profile(Profile(ProfileName.SEG, [

--- a/src/jpl/labcas/validation/validators/_core.py
+++ b/src/jpl/labcas/validation/validators/_core.py
@@ -346,12 +346,48 @@ class PixelSpacingValidator(Validator):
         return findings
 
 
-class ImagePositionPatientValidator(RegexValidator):
+class ImagePositionPatientValidator(Validator):
     '''A validator that checks the ImagePositionPatient tag.'''
 
-    description = 'ImagePositionPatient must be a triplet of numbers'
+    description = 'ImagePositionPatient must be a triplet of floating point numbers'
     tag = pydicom.tag.Tag((0x0020, 0x0032))
-    regex = re.compile(r'^\[-?\d+(\.\d+)?,\s*-?\d+(\.\d+)?,\s*-?\d+(\.\d+)?\]$')
+
+    def validate(self, potential_file: PotentialFile) -> set[ValidationFinding]:
+        '''Validate that ImagePositionPatient has exactly three floats (e.g. decimal or scientific notation).'''
+        findings: set[ValidationFinding] = set()
+        ds = potential_file.dcmread(stop_before_pixels=True, force=False)
+        elem = ds.get_item(self.tag)
+        if elem is None:
+            findings.add(ValidationFinding(
+                file=potential_file, value='tag missing', tag=self.tag,
+                description='ImagePositionPatient tag is missing'
+            ))
+            return findings
+        elem = convert_raw_data_element(elem)
+        value = elem.value
+        if value is None:
+            findings.add(ValidationFinding(
+                file=potential_file, value='value missing', tag=self.tag,
+                description='ImagePositionPatient tag has no value'
+            ))
+            return findings
+        values_iter = [value] if (isinstance(value, str) or not isinstance(value, Sequence)) else list(value)
+        if len(values_iter) != 3:
+            findings.add(ValidationFinding(
+                file=potential_file, value=value, tag=self.tag,
+                description=f'ImagePositionPatient must be exactly three values (got {len(values_iter)})'
+            ))
+            return findings
+        for i, v in enumerate(values_iter):
+            try:
+                float(v)
+            except (ValueError, TypeError):
+                findings.add(ValidationFinding(
+                    file=potential_file, value=value, tag=self.tag,
+                    description=f'ImagePositionPatient value {i + 1} must be a floating point number (decimal or scientific notation)'
+                ))
+                return findings
+        return findings
 
 
 class ImageOrientationPatientValidator(Validator):


### PR DESCRIPTION
## 📜 Summary

This pull request provides three updates in one:

1. (0020,0032) Image Position (Patient) now accepts positive, negative, or zero as possible values and validates exactly three floating point values (including in scientific notation)
2. The `PET standard` profile makes Window Center, Window Width, and Slice Thickness optional
3. Two new profiles
    a. `CT derived or post-processed`
    b. `MR derived or post-processed`


## 🩺 Test Data and/or Report

This was a big request I can't easily assemble a clear set of test DICOM files for these, so I'll rely on your _code review only_ to determine if it's correct.

I can at least show that in my own local set of test files, one of the new profiles for part ③ above is being detected and used; for example:

```csv
Site ID,Event ID,File Name,Profile,Score,Findings,Details
…
Images_Site_UB5yhu2StyPSLQ,6082370,1.2.826.0.1.3680043.2.135.737986.64139209.7.1644598263.625.13_0602_000148_1644598286020c.dcm,CT derived or post-processed,1.0,⚠️ Missing Required Tags,"(0018,1020) (SoftwareVersions), «tag missing», Failed core tag validation: Required tag not found in DICOM dataset: (0018,1020) SoftwareVersions — please review for completeness and format"
```
Under the "Profile" column you can see the new "CT derived or post-processed".



## 🧩 Related Issues

- #11 
