### PR TITLE
Resolve #9 by skipping files under a certain size threshold

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,10 +143,10 @@
         "filename": "pyproject.toml",
         "hashed_secret": "1b21650fca3caf5c234a77fcc47fb5f08cfcbd8a",
         "is_verified": false,
-        "line_number": 13,
+        "line_number": 14,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2025-11-12T23:17:28Z"
+  "generated_at": "2026-02-11T01:01:59Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = 'jpl.labcas.validation'
 dynamic = ['version']
 requires-python = '>=3.11'
 dependencies = [
+    'humanize ~= 4.15.0',
     'pydicom ~= 3.0.1',
     'pytesseract ~= 0.3.13',
     'pylibjpeg[all] ~= 2.1.0',

--- a/src/jpl/labcas/validation/_files.py
+++ b/src/jpl/labcas/validation/_files.py
@@ -17,6 +17,7 @@ class PotentialFile:
     site_id: str        # Blinded site ID
     event_id: str       # Event ID
     file_name: str      # File name
+    file_size: int      # File size in bytes
 
     # Regex for parsing organization parts from file paths
     _organization_re = re.compile(r'([^/]+)/(\d{7})/(.+)$')  # blah/blah/Images_site_XYX/1234567/f1/f2/…/file.dcm
@@ -24,6 +25,7 @@ class PotentialFile:
     def __init__(self, path: str, site_id: str = None, event_id: str = None):
         '''Initialize the potential file with the given file path and optional site and event IDs.'''
         self.path = path
+        self.file_size = os.path.getsize(path)
 
         search_result = self._organization_re.search(path)
         if search_result:

--- a/src/jpl/labcas/validation/const.py
+++ b/src/jpl/labcas/validation/const.py
@@ -11,3 +11,6 @@ IGNORED_FILES = {'.DS_Store', 'Thumbs.db', 'desktop.ini', 'DICOMDIR', 'DICOMDIR.
 
 # Folders whose contents we can skip completely
 IGNORED_FOLDERS = {'thumbnails'}
+
+# Minimum file size to be considered for validation, 25 KB
+MINIMUM_FILE_SIZE = 25 * 1024

--- a/src/jpl/labcas/validation/main.py
+++ b/src/jpl/labcas/validation/main.py
@@ -30,12 +30,12 @@ from ._files import PotentialFile
 from ._findings import Finding, ErrorFinding
 from ._profiles import get_profile, ProfileName
 from ._functions import check_directory, iterate_paths
-from .const import PHI_PII_THRESHOLD
+from .const import PHI_PII_THRESHOLD, MINIMUM_FILE_SIZE
 from .phi_pii_recognizers import PHI_PII_RECOGNIZERS, DEFAULT_PHI_PII_RECOGNIZER
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from multiprocessing import cpu_count
 from typing import Iterable
-import argparse, sys, logging, os, pydicom, pysolr, os.path, tempfile, sqlite3, threading, traceback
+import argparse, sys, logging, os, pydicom, pysolr, os.path, tempfile, sqlite3, threading, traceback, humanize
 
 
 __doc__ = '🛂 EDRN DICOM Validation: check for PHI/PII and compliance with EDRN core and MR requirements for DICOM tags'
@@ -110,9 +110,19 @@ def _scan_one(potential_file: PotentialFile) -> int | list[Finding]:
         - If db_path is None: list of Finding objects (for single-process mode)
     '''
     try:
-        # Short circuit: if the profile is Generic or NULL, skip full validation and report as warning
-        # (profile_name is a property that always resolves to a ProfileName, so None only before first access)
-        if potential_file.profile_name is None or potential_file.profile_name in (ProfileName.GENERIC, ProfileName.NULL, ProfileName.MISSING_IMAGE_TYPE):
+        if potential_file.file_size < MINIMUM_FILE_SIZE:
+            # File size heuristic: if the file isn't unexpectedly small, skip it
+            _logger.warning('🤷 Skipping file %s because it is unexpectedly small', potential_file)
+            humanized = humanize.naturalsize(potential_file.file_size)
+            findings = [ErrorFinding(
+                file=potential_file,
+                value=f'FAIL! File is unexpectedly small ({humanized})',
+                score=1.0,
+                error_message=f'Skipping file because it is unexpectedly small; file size is {potential_file.file_size} bytes but require a minimum of {MINIMUM_FILE_SIZE} bytes'
+            )]
+        elif potential_file.profile_name is None or potential_file.profile_name in (ProfileName.GENERIC, ProfileName.NULL, ProfileName.MISSING_IMAGE_TYPE):
+            # Short circuit: if the profile is Generic or NULL, skip full validation and report as warning
+            # (profile_name is a property that always resolves to a ProfileName, so None only before first access)
             _logger.warning('🤷 Skipping file %s because it does not have a recognized profile', potential_file)
             message = 'Skipping file because it does not have a recognized profile — FAIL!'
             if potential_file.profile_name == ProfileName.MISSING_IMAGE_TYPE:
@@ -124,6 +134,7 @@ def _scan_one(potential_file: PotentialFile) -> int | list[Finding]:
                 error_message=message
             )]
         else:
+            # Okay, full validation time
             findings: set[Finding] = set()
             findings.update(_recognizer.recognize(potential_file))
 


### PR DESCRIPTION
## 📜 Summary

This pull request adds an up-front check—before _all other_ checks—for the size of each DICOM file being examined.

If it's below 25kB in size, a failure is logged into the `.csv` files and no other PHI/PII or validation occurs. Otherwise, normal processing proceeds.

## 🩺 Test Data and/or Report

I created a test collection `runt-collection` with a test site `runt-site` and test event ID `1111111` in `testdata/issue/9/runt-collection/runt-site/1111111` and put 3 files into it:

- `1` — originally Prostate_MRI / uDUsCV9ikmtw / 1816383: 1_1816383.dcm, size 3296 bytes
- `2941` — originally Prostate_MRI / ElkuApuKkJXw2A / 9708141: 2941_9708141.dcm, size 6020 byes
- `I2703_7807378.dcm` — originally Lung_Team_Project_2 / ldytNSGnHnrBQ / 7807378: I2703_7807378.dcm, size 5860 bytes

Before modifying the software, the generated report contained the following:

[before.csv](https://github.com/user-attachments/files/25223288/before.csv)

After modifying the software, the report contained the following:

[after.csv](https://github.com/user-attachments/files/25223292/after.csv)



## 🧩 Related Issues

- #9 
