### PR TITLE
Resolve #24 by testing for small file sizes only on DICOM files

### DIFF
--- a/src/jpl/labcas/validation/main.py
+++ b/src/jpl/labcas/validation/main.py
@@ -110,8 +110,14 @@ def _scan_one(potential_file: PotentialFile) -> int | list[Finding]:
         - If db_path is None: list of Finding objects (for single-process mode)
     '''
     try:
-        if potential_file.file_size < MINIMUM_FILE_SIZE:
-            # File size heuristic: if the file isn't unexpectedly small, skip it
+        if potential_file.profile_name is None or potential_file.profile_name in (ProfileName.GENERIC, ProfileName.NULL, ProfileName.MISSING_IMAGE_TYPE):
+            # Short circuit: not a recognized DICOM file (non-DICOM or unrecognized profile).
+            # Do not add to report — we want only DICOM files in the report.
+            # Do not check file size here — that applies only to recognized DICOM files.
+            _logger.warning('🤷 Skipping file %s because it does not have a recognized profile (excluding from report)', potential_file)
+            findings = []
+        elif potential_file.file_size < MINIMUM_FILE_SIZE:
+            # File size heuristic: only for recognized DICOM files; non-DICOM files are handled above
             _logger.warning('🤷 Skipping file %s because it is unexpectedly small', potential_file)
             humanized = humanize.naturalsize(potential_file.file_size)
             findings = [ErrorFinding(
@@ -119,19 +125,6 @@ def _scan_one(potential_file: PotentialFile) -> int | list[Finding]:
                 value=f'FAIL! File is unexpectedly small ({humanized})',
                 score=1.0,
                 error_message=f'Skipping file because it is unexpectedly small; file size is {potential_file.file_size} bytes but require a minimum of {MINIMUM_FILE_SIZE} bytes'
-            )]
-        elif potential_file.profile_name is None or potential_file.profile_name in (ProfileName.GENERIC, ProfileName.NULL, ProfileName.MISSING_IMAGE_TYPE):
-            # Short circuit: if the profile is Generic or NULL, skip full validation and report as warning
-            # (profile_name is a property that always resolves to a ProfileName, so None only before first access)
-            _logger.warning('🤷 Skipping file %s because it does not have a recognized profile', potential_file)
-            message = 'Skipping file because it does not have a recognized profile — FAIL!'
-            if potential_file.profile_name == ProfileName.MISSING_IMAGE_TYPE:
-                message += ' — note: it has a recognized SOPClassUID but no ImageType value, which is still FAIL!'
-            findings = [ErrorFinding(
-                file=potential_file,
-                value='FAIL! No valid profile found for file',
-                score=1.0,
-                error_message=message
             )]
         else:
             # Okay, full validation time


### PR DESCRIPTION
## 📜 Summary

This pull request modifies the file-size detection to only flag DICOM files and not any other random file (like an XML file) that might be on the LabCAS disk. The majority of DICOM files do not end in `.dcm` so file-type detection happens _first_ by reading the file, and then file size detection happens _second_ by reading the filesystem.

## 🩺 Test Data and/or Report

I created a test collection `runt-collection` with a test site `runt-site` and test event ID `1111111` in `testdata/issue/24/runt-collection/runt-site/1111111` and put 2 files into it:

- `1` — originally from Prostate_MRI, a valid DICOM file of 39504 byes
- `non-dcm.xml`, an XML file.

Before modifying the software, the generated report contained the following:

[before.csv](https://github.com/user-attachments/files/25527260/before.csv)

After modifying the software, the report contained the following:


[after.csv](https://github.com/user-attachments/files/25527270/after.csv)



## 🧩 Related Issues

- #24 