### PR TITLE
Resolve #22 by reducing the min file size threshold

### DIFF
--- a/src/jpl/labcas/validation/const.py
+++ b/src/jpl/labcas/validation/const.py
@@ -12,5 +12,5 @@ IGNORED_FILES = {'.DS_Store', 'Thumbs.db', 'desktop.ini', 'DICOMDIR', 'DICOMDIR.
 # Folders whose contents we can skip completely
 IGNORED_FOLDERS = {'thumbnails'}
 
-# Minimum file size to be considered for validation, 25 KB
-MINIMUM_FILE_SIZE = 25 * 1024
+# Minimum file size to be considered for validation, 15 KB
+MINIMUM_FILE_SIZE = 15 * 1024


### PR DESCRIPTION
## 📜 Summary

This pull request reduces the minimum file size threshold from 25 KB to 15 KB in order to validate more DICOM files found in `Prostate_MRI/Images_Site_rvIOs4uv8Rbfng/6683197`.


## 🩺 Test Data and/or Report

I created a test "collection" consisting of a single 15KB DICOM file from `Prostate_MRI/Images_Site_rvIOs4uv8Rbfng/6683197`. Prior to modifying the software, the finding report is as follows:

[before.csv](https://github.com/user-attachments/files/25527531/before.csv)

After modifying the software and rerunning it, there was no `after.csv`, meaning the validator validated it and found the size acceptable.


## 🧩 Related Issues

- #22 
