### PR TITLE
Resolve #33 by adding WindowWidthValidator to the required list for SC

### DIFF
--- a/src/jpl/labcas/validation/_profiles.py
+++ b/src/jpl/labcas/validation/_profiles.py
@@ -250,6 +250,7 @@ register_profile(Profile(ProfileName.SC, [
     validators.PixelRepresentationValidator(),
     validators.PhotometricInterpretationValidator(),    
     validators.WindowCenterValidator(),
+    validators.WindowWidthValidator(),
 ], [
     validators.ImageTypeValidator(),
     validators.SeriesDescriptionValidator(),


### PR DESCRIPTION
## 📜 Summary

This pull request adds `WindowWidthValidator` to the list of required validators for the `SC` profile. It was inadvertently left out.


## 🩺 Test Data and/or Report

Before modifying the software, I created a test collection using the file `Lung_Team_Project_2/Images_Site_AvinPOWpghrek/5610103/IM00003_5610103.dcm` called `LTP2/Images_Site_xyz/5610103/IM00003`. The Validator generated the following report:

[before.csv](https://github.com/user-attachments/files/25691537/before.csv)

Note that WindowCenter is in the report, but WindowWidth is not.

I modified the software to resolve the issue and re-ran the report to generate the following:

[after.csv](https://github.com/user-attachments/files/25691550/after.csv)

Note that this report is one line longer and includes WindowWidth.


## 🧩 Related Issues

- #33 
